### PR TITLE
Rename chatbot.html for consistency in file naming

### DIFF
--- a/api/utils/pathConfig.js
+++ b/api/utils/pathConfig.js
@@ -31,7 +31,7 @@ const jsCity3DDIR = path.join(jsPagesDir, 'city3D');
 // Template paths
 const headerPath = path.join(utilsDir, 'header.html');
 const footerPath = path.join(utilsDir, 'footer.html');
-const chatBotPath = path.join(utilsDir, 'chatbot.html');
+const chatBotPath = path.join(utilsDir, 'chatBot.html');
 
 // HTML pages
 const homePage = path.join(pagesDir, 'home.html');


### PR DESCRIPTION
Rename the file to chatBot.html to maintain consistent naming conventions across the project.